### PR TITLE
Zot/reduce private dependencies

### DIFF
--- a/src/forges/Bitbucket/commits.jl
+++ b/src/forges/Bitbucket/commits.jl
@@ -1,19 +1,17 @@
-@json struct Author
+@json_struct struct Author
     raw::String
     user::User
 end
-@json_struct Author
 
-@json struct Participant
+@json_struct struct Participant
     user::User
     role::String
     approved::Bool
     state::String
     participated_on::Date
 end
-@json_struct Participant
 
-@json struct Commit
+@json_struct struct Commit
     hash::String
     data::DateTime
     author::Author
@@ -24,7 +22,6 @@ end
     repository::Repo
     participants::Vector{Participant}
 end
-@json_struct Commit
 
 endpoint(::BitbucketAPI, ::typeof(get_commit), workspace::AStr, repo::AStr, ref::AStr) =
     Endpoint(:GET, "/repositories/$workspace/$repo/commit/$ref")

--- a/src/forges/Bitbucket/pagination.jl
+++ b/src/forges/Bitbucket/pagination.jl
@@ -6,7 +6,7 @@
     values::Vector{T}
     _extras::NamedTuple
 end
-@json_struct Page
+@struct_def Page
 
 struct BBPaginator{FRG, P}
     api::FRG

--- a/src/forges/Bitbucket/pull_requests.jl
+++ b/src/forges/Bitbucket/pull_requests.jl
@@ -1,21 +1,18 @@
-@json struct PullRequestBranch
+@json_struct struct PullRequestBranch
     default_merge_strategy::String
     merge_strategies::Vector{String}
     name::String
 end
-@json_struct PullRequestBranch
 
-@json struct PullRequestCommit
+@json_struct struct PullRequestCommit
     hash::String
 end
-@json_struct PullRequestCommit
 
-@json struct PullRequestEndpoint
+@json_struct struct PullRequestEndpoint
     branch::Branch
     commit::PullRequestCommit
     repository::Repo
 end
-@json_struct PullRequestEndpoint
 
 """
     RenderedPullRequestMarkup
@@ -23,14 +20,13 @@ end
 title, description, and reason are Dicts like:
 Dict("raw"=> "<string>", "markup"=> "<string>", "html"=> "<string>")
 """
-@json struct RenderedPullRequestMarkup
+@json_struct struct RenderedPullRequestMarkup
     description::Dict{String, Any}
     reason::Dict{String, Any}
     title::Dict{String, Any}
 end
-@json_struct RenderedPullRequestMarkup
 
-@json struct PullRequest
+@json_struct struct PullRequest
     author::User
     close_source_branch::Bool
     closed_by::Union{User, Nothing}
@@ -52,7 +48,6 @@ end
     title::String
     updated_on::DateTime
 end
-@json_struct PullRequest
 
 @not_implemented(::BitbucketAPI, ::typeof(get_pull_request), ::String, ::String, ::UUID)
 @not_implemented(::BitbucketAPI, ::typeof(get_pull_request), ::UUID, ::UUID)

--- a/src/forges/Bitbucket/repositories.jl
+++ b/src/forges/Bitbucket/repositories.jl
@@ -1,25 +1,22 @@
-@json struct Project
+@json_struct struct Project
     key::String
     links::NamedTuple
     name::String
     uuid::UUID
 end
-@json_struct Project
 
-@json struct Branch
+@json_struct struct Branch
     name::String
 end
-@json_struct Branch
 
-@json struct Workspace
+@json_struct struct Workspace
     links::NamedTuple
     name::String
     slug::String
     uuid::UUID
 end
-@json_struct Workspace
 
-@json mutable struct Repo
+@json_struct mutable struct Repo
     created_on::DateTime
     description::String
     fork_policy::String
@@ -40,7 +37,6 @@ end
     website::String
     workspace::Workspace
 end
-@json_struct Repo
 
 @not_implemented(::BitbucketAPI, ::typeof(get_user_repos))
 @not_implemented(::BitbucketAPI, ::typeof(get_user_repos), ::String)

--- a/src/forges/Bitbucket/tags.jl
+++ b/src/forges/Bitbucket/tags.jl
@@ -1,9 +1,8 @@
-@json struct Tag
+@json_struct struct Tag
     links::NamedTuple
     name::String
     target::Commit
 end
-@json_struct Tag
 
 endpoint(::BitbucketAPI, ::typeof(get_tags), workspace::String, repo::String) = Endpoint(:GET, "/repositories/$workspace/$repo/refs/tags")
 @not_implemented(::BitbucketAPI, ::typeof(get_tags), ::UUID)

--- a/src/forges/Bitbucket/users.jl
+++ b/src/forges/Bitbucket/users.jl
@@ -1,4 +1,4 @@
-@json struct User
+@json_struct struct User
     account_id::String
     account_status::String
     created_on::DateTime
@@ -13,13 +13,11 @@
     uuid::UUID
     website::String
 end
-@json_struct User
 
-@json struct WorkspaceMembership
+@json_struct struct WorkspaceMembership
     links::NamedTuple
     user::User
 end
-@json_struct WorkspaceMembership
 
 endpoint(::BitbucketAPI, ::typeof(get_user)) = Endpoint(:GET, "/user")
 endpoint(::BitbucketAPI, ::typeof(get_user), name::AStr) =


### PR DESCRIPTION
This eliminates the depency on our version of StructTypes since StructTypes now properly supports NamedTuples and this also cleans up some code.